### PR TITLE
Add alt name for Template Analyzer.

### DIFF
--- a/data/microsoft.json
+++ b/data/microsoft.json
@@ -17,7 +17,8 @@
         "template-analyzer",
         "Template Analyzer",
         "BPA",
-        "Best Practice Analyzer"
+        "Best Practice Analyzer",
+        "Template BPA"
       ],
       "category": "IaC"
     },

--- a/data/microsoft.json
+++ b/data/microsoft.json
@@ -18,7 +18,8 @@
         "Template Analyzer",
         "BPA",
         "Best Practice Analyzer",
-        "Template BPA"
+        "Template BPA",
+        "Template Best Practice Analyzer"
       ],
       "category": "IaC"
     },


### PR DESCRIPTION
Adding an alternate name for template analyzer. Running guardian in a build pipeline we received "Template BPA" for the driver name.