### PR TITLE
feat(onboard-defender-cli): make default auth path, fix bugs, always update CLI

### DIFF
--- a/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
+++ b/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
@@ -188,6 +188,14 @@ The FPA-scoped login needs the tenant id of the tenant onboarded with DfD. List 
 user can access with the bundled script's `ListTenants` phase — it runs a baseline `az login` if
 no account is cached, then emits the candidates as objects (`index`, `tenantId`, `label`, ...):
 
+> **Logins try the browser first, then fall back to device code.** Both the baseline login here
+> and the FPA login in B1 attempt an interactive browser `az login`; if that fails or doesn't
+> complete within ~2 minutes (e.g. a headless/agent shell with no browser), the script
+> automatically retries with `az login --use-device-code`. When the device-code path runs it
+> prints a `https://microsoft.com/devicelogin` URL and a one-time code — **surface that URL and
+> code to the user verbatim** and wait for them to complete sign-in. Do **not** improvise a
+> different login flow or swap in `az account list`; let the phases run.
+
 ```powershell
 # Re-resolve $bootstrap if authenticating in a fresh session.
 & $bootstrap -Step ListTenants
@@ -197,6 +205,14 @@ no account is cached, then emits the candidates as objects (`index`, `tenantId`,
 > them confirm which tenant is onboarded with DfD. If only one tenant is returned, use it.
 > Picking the wrong tenant makes the FPA token request fail with `AADSTS500011` ("resource
 > principal named ... not found").
+
+> **`az account tenant list` needs the `account` extension.** This phase enumerates tenants with
+> `az account tenant list`, which lives in the `account` dynamic *preview* extension. The script
+> pre-sets `extension.use_dynamic_install=yes_without_prompt` and
+> `extension.dynamic_install_allow_preview=true` so az installs it silently. Do **not** improvise
+> a workaround if you see an extension-install prompt — re-run `-Step ListTenants` (the settings
+> are applied each run), or set those two `az config` values manually and retry. Never skip
+> tenant selection.
 
 #### B1. Authenticate against the FPA and set the tenant env var
 
@@ -241,4 +257,6 @@ After any of these, the user can reply `fix` (or `fix #N #M`) to hand the top fi
 | `-Step Verify` — `defender` not on PATH | Open a new terminal so the persistent PATH is picked up, then re-run `-Step Verify`. To patch the current session manually: Windows: `$env:PATH += ";$HOME\.mdc"`; Linux/macOS: `$env:PATH += ":$HOME/.mdc"` |
  | `-Step AuthLegacy` — "Missing required value(s)" | Gather `GDN_MDC_CLI_CLIENT_ID` / `GDN_MDC_CLI_TENANT_ID` from the user (issued by the DfD onboarding admin) and pass them as `-ClientId` / `-TenantId` |
  | `-Step AuthAspm` — `az login` fails with `AADSTS500011` | Wrong tenant. Re-run `-Step ListTenants`, have the user confirm the DfD-onboarded tenant, then re-run `-Step AuthAspm -TenantId <confirmed>` |
+ | `-Step ListTenants` / `-Step AuthAspm` — az prompts to install the `account` extension (Y/n) or hangs | The `account` extension (for `az account tenant list`) is missing. The script auto-configures silent install; if you still see the prompt (older az / config not applied), run `az config set extension.use_dynamic_install=yes_without_prompt` and `az config set extension.dynamic_install_allow_preview=true`, then re-run the step. Do not bypass tenant selection. |
+ | `-Step ListTenants` / `-Step AuthAspm` — `az login` hangs or fails with an interactive/browser prompt | A headless shell has no browser. The script tries browser login first and auto-falls back to `az login --use-device-code` after ~2 minutes; surface the printed `microsoft.com/devicelogin` URL + code to the user and wait for sign-in. Do not switch to a different login flow or use `az account list` to work around it. |
  | Linux/macOS — `defender: permission denied` | `chmod +x ~/.mdc/defender` |

--- a/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
+++ b/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
@@ -182,9 +182,9 @@ and retry — Path B cannot proceed without `az`.
 > exit code. On Linux, run `-Step EnsureAzureCli` only where passwordless `sudo` is configured,
 > or install `az` manually beforehand.
 
-#### B0. Select the DfD data tenant
+#### B0. Select the tenant
 
-The FPA-scoped login needs the tenant id of the tenant onboarded with DfD. List the tenants the
+The FPA-scoped login needs the tenant id of the tenant to use. List the tenants the
 user can access with the bundled script's `ListTenants` phase — it runs a baseline `az login` if
 no account is cached, then emits the candidates as objects (`index`, `tenantId`, `label`, ...):
 
@@ -202,7 +202,7 @@ no account is cached, then emits the candidates as objects (`index`, `tenantId`,
 ```
 
 > **Surface the choice to the user through the agent UI** (e.g., `vscode_askQuestions`) and have
-> them confirm which tenant is onboarded with DfD. If only one tenant is returned, use it.
+> them confirm which tenant they would like to use. If only one tenant is returned, use it.
 > Picking the wrong tenant makes the FPA token request fail with `AADSTS500011` ("resource
 > principal named ... not found").
 
@@ -256,7 +256,7 @@ After any of these, the user can reply `fix` (or `fix #N #M`) to hand the top fi
 | `-Step Install` — Authenticode `NotSigned` / `HashMismatch` / non-Microsoft signer | Do NOT proceed. The bundled script aborts automatically on Windows. Report failure to the user; re-run `-Step Install` to re-download and re-verify |
 | `-Step Verify` — `defender` not on PATH | Open a new terminal so the persistent PATH is picked up, then re-run `-Step Verify`. To patch the current session manually: Windows: `$env:PATH += ";$HOME\.mdc"`; Linux/macOS: `$env:PATH += ":$HOME/.mdc"` |
  | `-Step AuthLegacy` — "Missing required value(s)" | Gather `GDN_MDC_CLI_CLIENT_ID` / `GDN_MDC_CLI_TENANT_ID` from the user (issued by the DfD onboarding admin) and pass them as `-ClientId` / `-TenantId` |
- | `-Step AuthAspm` — `az login` fails with `AADSTS500011` | Wrong tenant. Re-run `-Step ListTenants`, have the user confirm the DfD-onboarded tenant, then re-run `-Step AuthAspm -TenantId <confirmed>` |
+ | `-Step AuthAspm` — `az login` fails with `AADSTS500011` | Wrong tenant. Re-run `-Step ListTenants`, have the user confirm the tenant, then re-run `-Step AuthAspm -TenantId <confirmed>` |
  | `-Step ListTenants` / `-Step AuthAspm` — az prompts to install the `account` extension (Y/n) or hangs | The `account` extension (for `az account tenant list`) is missing. The script auto-configures silent install; if you still see the prompt (older az / config not applied), run `az config set extension.use_dynamic_install=yes_without_prompt` and `az config set extension.dynamic_install_allow_preview=true`, then re-run the step. Do not bypass tenant selection. |
  | `-Step ListTenants` / `-Step AuthAspm` — `az login` hangs or fails with an interactive/browser prompt | A headless shell has no browser. The script tries browser login first and auto-falls back to `az login --use-device-code` after ~2 minutes; surface the printed `microsoft.com/devicelogin` URL + code to the user and wait for sign-in. Do not switch to a different login flow or use `az account list` to work around it. |
  | Linux/macOS — `defender: permission denied` | `chmod +x ~/.mdc/defender` |

--- a/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
+++ b/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
@@ -115,16 +115,23 @@ the Copilot CLI.
 
 ## Step 5: Authenticate
 
-The CLI exposes two distinct authentication paths. Set up the one(s) matching the scans the user plans to run. If unsure, set up both.
+The CLI exposes two distinct authentication paths. **Path B (ASPM auth-push) is the default — set it up now during onboarding.** Path A is **deferred**: it is needed only for the local scan commands (`scan image`, `scan fs`, `scan model`, `scan sbom`) and should **not** be set up during onboarding. The `run-security-scan` skill routes the user back here for Path A on demand, the first time they run a local scan.
 
-| Scan type | Auth path |
-|-----------|-----------|
-| `scan image`, `scan fs`, `scan model`, `scan sbom` | **Path A — legacy `defender auth login`** (uses `GDN_MDC_CLI_*`). |
-| `status result --latest`, `scan ai-scan submit` | **Path B — ASPM auth-push** (interactive `az login` to the DfD FPA). |
+| Scan type | Auth path | When to set up |
+|-----------|-----------|----------------|
+| `status result --latest`, `scan ai-scan submit` | **Path B — ASPM auth-push** (interactive `az login` to the DfD FPA). | **Now — default.** |
+| `scan image`, `scan fs`, `scan model`, `scan sbom` | **Path A — legacy `defender auth login`** (uses `GDN_MDC_CLI_*`). | On demand — only when a local scan is requested. |
+
+By default, complete **Path B** now and stop. Set up **Path A** only if the user explicitly asks to run a local scan during onboarding.
 
 ---
 
-### Path A — Legacy `defender auth login` (image / fs / model / sbom)
+### Path A — Legacy `defender auth login` (image / fs / model / sbom) — on-demand only
+
+> **Do not run Path A during initial onboarding.** It is required only when the user actually
+> invokes a local scan (`scan image` / `scan fs` / `scan model` / `scan sbom`); the
+> `run-security-scan` skill routes back here at that point. If you are onboarding for the first
+> time, complete **Path B** (below) and stop.
 
 **First-time configuration** — before the very first `defender auth login`, two environment variables must be set. These persist across sessions; skip this step if they are already defined.
 
@@ -149,9 +156,10 @@ Wait for the browser-based login to complete. The phase prints `defender auth st
 
 ---
 
-### Path B — ASPM auth-push for `defender status result --latest` or `scan ai-scan` (interactive `az login` to FPA)
+### Path B — ASPM auth-push for `defender status result --latest` or `scan ai-scan` (interactive `az login` to FPA) — default
 
-Use this only when the user is running `defender status result --latest` or `defender scan ai-scan submit`. No client secret is needed.
+> **This is the default authentication path — always set it up during onboarding.** It covers
+> `defender status result --latest` and `defender scan ai-scan submit`. No client secret is needed.
 
 #### B-pre. Ensure Azure CLI is installed
 

--- a/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
+++ b/plugin/defender-code-security/skills/onboard-defender-cli/SKILL.md
@@ -34,13 +34,15 @@ For official documentation, see:
 - **PowerShell** (any platform — PowerShell Core or Windows PowerShell)
 - **Azure CLI (`az`)** — only required for **Path B** (ASPM auth-push). Path B installs it if missing; the install steps below and the legacy Path A do not need it.
 
-## Step 1: Check if defender is already available
+## Step 1: Check the currently installed version (informational)
 
 ```powershell
 defender --version
 ```
 
-If the command succeeds, the CLI is already installed. Done — return to the calling skill.
+This is informational only — **do not stop if it succeeds.** Onboarding always installs the
+latest CLI in Step 2, replacing any existing version, so a user on an old build is upgraded in
+place. Note the reported version (or that the command was not found) and continue to Step 2.
 
 ## The bundled bootstrap script
 
@@ -64,7 +66,8 @@ remote installer is a separate trust boundary from this local script.
 ## Step 2: Install the CLI
 
 Download Microsoft's `InstallCli.ps1`, verify its Authenticode signature (Windows), and run it
-to install the `defender` binary to `~/.mdc/`:
+to install the `defender` binary to `~/.mdc/`. This always installs the **latest** version,
+overwriting any existing install — so re-running onboarding upgrades an out-of-date CLI in place:
 
 ```powershell
 & $bootstrap -Step Install

--- a/plugin/defender-code-security/skills/onboard-defender-cli/scripts/bootstrap.ps1
+++ b/plugin/defender-code-security/skills/onboard-defender-cli/scripts/bootstrap.ps1
@@ -95,6 +95,51 @@ function Invoke-Native {
     }
 }
 
+function Invoke-AzLogin {
+    # Prefer an interactive browser login, but fall back to the device-code flow if the
+    # browser attempt fails or does not complete in time. A browser login hangs in a
+    # headless/agent shell that has no browser to open, so the browser attempt is bounded
+    # by a timeout: if it does not finish, we cancel it and retry with --use-device-code
+    # (which prints a URL + one-time code that works headlessly). The same login args
+    # (tenant / scope / --allow-no-subscriptions / ...) are passed through to both attempts.
+    param(
+        [Parameter(ValueFromRemainingArguments)][string[]] $Arguments
+    )
+
+    $browserTimeoutSec = 120
+
+    # Run the browser attempt as a background job so a missing browser can't hang the phase
+    # forever. The job inherits PATH + the az token cache (~/.azure), so a successful login
+    # there persists for the subsequent `az account ...` calls in this process.
+    Write-Host "Attempting interactive browser login (falls back to device code after ${browserTimeoutSec}s)..."
+    $job = Start-Job -ScriptBlock {
+        param($AzArgs)
+        $out = & az @AzArgs 2>&1 | Out-String
+        [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $out }
+    } -ArgumentList (, (@('login') + $Arguments))
+
+    $result = $null
+    if (Wait-Job $job -Timeout $browserTimeoutSec) {
+        $result = Receive-Job $job
+    } else {
+        Write-Host "Browser login did not complete within ${browserTimeoutSec}s — falling back to device code."
+        Stop-Job $job -ErrorAction SilentlyContinue
+    }
+    Remove-Job $job -Force -ErrorAction SilentlyContinue
+
+    if ($result -and $result.ExitCode -eq 0) {
+        if ($result.Output) { Write-Host $result.Output.Trim() }
+        return
+    }
+    if ($result -and $result.Output) {
+        Write-Host "Browser login failed; falling back to device code:`n$($result.Output.Trim())"
+    }
+
+    # Fallback: device-code flow in the foreground so the user sees the URL + code live.
+    # Invoke-Native so a cancelled/expired device-code login fails the phase loudly.
+    Invoke-Native az login @Arguments --use-device-code
+}
+
 function Add-PersistentExport {
     # Persist an env var on Linux/macOS by writing an idempotent `export` line to the
     # user's shell rc file. On Windows, [Environment]::SetEnvironmentVariable(...,'User')
@@ -157,8 +202,20 @@ function Get-AzTenant {
     # evaluates as truthy regardless of success.
     az account show 2>$null 1>$null
     if ($LASTEXITCODE -ne 0) {
-        az login | Out-Null
+        # Browser login first, with an automatic device-code fallback for headless/agent
+        # shells (see Invoke-AzLogin). --allow-no-subscriptions so a user whose only access
+        # is the subscription-less DfD data tenant can still sign in.
+        Invoke-AzLogin --allow-no-subscriptions
     }
+    # `az account tenant list` is provided by the `account` dynamic *preview* extension, which
+    # is not installed by default. Without the two settings below, az interactively prompts
+    # ("The command requires the extension account. Do you want to install it now? (Y/n):"),
+    # which hangs in a non-interactive/agent shell and makes this phase fail. Configure az to
+    # install the extension silently (incl. preview) so the command runs unattended. Both are
+    # best-effort: suppress output and ignore failures so an older az without these keys still
+    # proceeds (it will just prompt, matching prior behaviour).
+    az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors 2>$null 1>$null
+    az config set extension.dynamic_install_allow_preview=true --only-show-errors 2>$null 1>$null
     # Use `az account tenant list`, not `az account list`: the latter only returns tenants
     # that have a subscription. Path B logs in with --allow-no-subscriptions, so the DfD
     # data tenant may have none and would be invisible here. `az account tenant list`
@@ -366,9 +423,10 @@ function Invoke-AuthAspm {
     # FPA-scoped login: the --scope <fpa-app-id>/Defender.InteractiveLogin requests a delegated
     # token whose `aud` is the FPA. --allow-no-subscriptions is required because the FPA app is
     # not bound to any Azure subscription. A generic `az login` will not produce an accepted token.
-    # Use Invoke-Native: a failed/cancelled login (e.g. wrong tenant / AADSTS500011) must NOT
-    # fall through and persist a bad DEFENDER_DFD_TENANT_ID.
-    Invoke-Native az login `
+    # Invoke-AzLogin tries browser login first and falls back to device code for headless/agent
+    # shells. It runs through Invoke-Native, so a failed/cancelled login (e.g. wrong tenant /
+    # AADSTS500011) throws and does NOT fall through to persist a bad DEFENDER_DFD_TENANT_ID.
+    Invoke-AzLogin `
         --tenant $TenantId `
         --scope "$FpaAppId/Defender.InteractiveLogin" `
         --allow-no-subscriptions


### PR DESCRIPTION
Set up Path B (ASPM auth-push via az login to the DfD FPA) during onboarding by default. Defer Path A (legacy 'defender auth login') to on-demand, triggered by run-security-scan only when a local scan (image/fs/model/sbom) is requested.